### PR TITLE
Terraform hotfix

### DIFF
--- a/ter-homeworks/05/src/demonstration1/.gitignore
+++ b/ter-homeworks/05/src/demonstration1/.gitignore
@@ -1,0 +1,16 @@
+# Local .terraform directories and files
+**/.terraform/*
+.terraform*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# own secret vars store.
+personal.auto.tfvars
+
+#checkov
+.external_modules
+
+#ansible
+*.cfg

--- a/ter-homeworks/05/src/demonstration1/cloud-init.yml
+++ b/ter-homeworks/05/src/demonstration1/cloud-init.yml
@@ -1,0 +1,13 @@
+#cloud-config
+users:
+  - name: ubuntu
+    groups: sudo
+    shell: /bin/bash
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    ssh_authorized_keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDPXmhw8Z72tEeCJ7M/q1Yr8NUflzwcdehG4qBPvModvk+PXxUpo60A+v5zswg8cMk8jThbDcOL9dwMeQBS23ArbiuteFaHN2q4yTbLn3LtLkwFaHzI3BRq4wKmmirCm32Z9P9xe0ZagQp97M2RuKmaMnHIMCxzwpPSYn1hTbxrncXYV1K9IqUv6SqSas2vFuRoIhOuJkzeeY2Ypno7grImPYFzk2Jt7vbZp3iS7DjfrEcWd1KkSl8nhoWnffJtH3m00JhYt9xPeCszbMafXWgNdZunCkGCwnAAzFxzZP91gZnwneVFgp0CK8qG8MkROR6o3+6cbW2NrEzj4YIVgrM0AFawSwFDEr+CiEdKHlNH5hI574b/UUJMHVL1A9wKpUYnQV0YoWdteDi2mwGYMkAYkDC3DjHg+0Swab9NU/D+AUDqngfZxkJdJn6CHIn9kOSQAuoLFJFqozFMPOzNCXhJS255a5as5Zr/WsmTB4TLMNPhV4LMmpKS00zdF0kmoyU= udjin@yoga7
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCtPnfjgdy85DXfFCEQBTA9syvs906biuj9kkVL2mjm1E+MEz1HGF/6FMNdeeWyFc3ks2qyXVSl1lVuV54fcUbo88UyQUvoj9p5U1+Y3vV+Ed7z3XN7IkHzHmJjfDaEySBT0upGQTQ2VkTJUxqEqsbJN2oAxDEPd+ltF0ecDDPrWfsnmQPTBeiaE+XUKqPg3wR8Lu8Iy20/9pf6+qjHwvFUWmneRLT6xJghpru8P/MYILo3cq3uvcWb7umHwh9aMBz6D/KNgLifTz0abSb/JrHkPjLhCec4z35qxDe9Ocsubtd4J/X3fRsh7qNYJwLsGoEmvixZCPJ3tDn8g0j7Z2tONQXkRTCRgEP4hI3z6+5MtRWQZ6E+MuhOASpAom7Ql3tFvYWsNAp/KyvXydSob3bHBe3UjnbXCIl+T9z9+GgHfEsyw+B3wuy5LknOjBu5lhn3dREIyJYcVJORwOMFAKm8mRd6ceiRjlykGrppLj26yq+y4IzZJFUEpbRvJ0b/HVE=
+package_update: true
+package_upgrade: false
+packages:
+ - vim

--- a/ter-homeworks/05/src/demonstration1/demonstration2.md
+++ b/ter-homeworks/05/src/demonstration1/demonstration2.md
@@ -1,0 +1,15 @@
+terraform state list
+
+terraform state show 'yandex_vpc_network.develop'
+
+terraform state show 'module.test-vm.yandex_compute_instance.vm[0]'
+
+terraform apply -target module.test-vm
+
+terraform apply -target module.test-vm -replace='module.test-vm.yandex_compute_instance.vm[0]'
+
+terraform state show 'module.test-vm.yandex_compute_instance.vm[0]' | grep 'id'
+
+terraform state rm 'module.test-vm.yandex_compute_instance.vm[0]'
+
+terraform import 'module.test-vm.yandex_compute_instance.vm[0]' fhm1g61rfod251rpdeqg #<VM.ID>

--- a/ter-homeworks/05/src/demonstration1/main.tf
+++ b/ter-homeworks/05/src/demonstration1/main.tf
@@ -1,0 +1,67 @@
+terraform {
+  required_providers {
+    yandex = {
+      source = "yandex-cloud/yandex"
+    }
+  }
+  required_version = ">=0.13"
+
+  backend "s3" {
+    endpoint   = "storage.yandexcloud.net"
+    bucket    = "tf-state-my"
+    region    = "ru-central1"
+    key       = "terraform.tfstate"
+
+    skip_region_validation      = true
+    skip_credentials_validation = true
+
+    dynamodb_endpoint = "https://docapi.serverless.yandexcloud.net/ru-central1/b1gu7l74om4kd99b6hhf/etn9546vklnkk0s670em"
+    dynamodb_table    = "tflock-develop"
+  }
+
+}
+
+provider "yandex" {
+  token     = var.token
+  cloud_id  = var.cloud_id
+  folder_id = var.folder_id
+  zone      = var.default_zone
+}
+
+
+#создаем облачную сеть
+resource "yandex_vpc_network" "develop" {
+  name = "develop"
+}
+
+#создаем подсеть
+resource "yandex_vpc_subnet" "develop" {
+  name           = "develop-ru-central1-a"
+  zone           = "ru-central1-a"
+  network_id     = yandex_vpc_network.develop.id
+  v4_cidr_blocks = ["10.0.1.0/24"]
+}
+
+module "test-vm" {
+  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  env_name        = "develop"
+  network_id      = yandex_vpc_network.develop.id
+  subnet_zones    = ["ru-central1-a"]
+  subnet_ids      = [ yandex_vpc_subnet.develop.id ]
+  instance_name   = "web"
+  instance_count  = 2
+  image_family    = "ubuntu-2004-lts"
+  public_ip       = true
+  
+  metadata = {
+      user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
+      serial-port-enable = 1
+  }
+
+}
+
+#Пример передачи cloud-config в ВМ для демонстрации №3
+data "template_file" "cloudinit" {
+ template = file("./cloud-init.yml")
+}
+

--- a/ter-homeworks/05/src/demonstration1/personal.auto.tfvars_example
+++ b/ter-homeworks/05/src/demonstration1/personal.auto.tfvars_example
@@ -1,0 +1,3 @@
+token  =  ""
+cloud_id  = ""
+folder_id = ""

--- a/ter-homeworks/05/src/demonstration1/terraformrc
+++ b/ter-homeworks/05/src/demonstration1/terraformrc
@@ -1,0 +1,9 @@
+provider_installation {
+  network_mirror {
+    url = "https://terraform-mirror.yandexcloud.net/"
+    include = ["registry.terraform.io/*/*"]
+  }
+  direct {
+    exclude = ["registry.terraform.io/*/*"]
+  }
+}

--- a/ter-homeworks/05/src/demonstration1/variables.tf
+++ b/ter-homeworks/05/src/demonstration1/variables.tf
@@ -1,0 +1,37 @@
+###cloud vars
+variable "token" {
+  type        = string
+  description = "OAuth-token; https://cloud.yandex.ru/docs/iam/concepts/authorization/oauth-token"
+}
+
+variable "cloud_id" {
+  type        = string
+  description = "https://cloud.yandex.ru/docs/resource-manager/operations/cloud/get-id"
+}
+
+variable "folder_id" {
+  type        = string
+  description = "https://cloud.yandex.ru/docs/resource-manager/operations/folder/get-id"
+}
+
+variable "default_zone" {
+  type        = string
+  default     = "ru-central1-a"
+  description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
+}
+variable "default_cidr" {
+  type        = list(string)
+  default     = ["10.0.1.0/24"]
+  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
+}
+
+variable "vpc_name" {
+  type        = string
+  default     = "develop"
+  description = "VPC network&subnet name"
+}
+
+variable "public_key" {
+  type    = string
+  default = ""
+}

--- a/ter-homeworks/05/src/demonstration1/variables.tf
+++ b/ter-homeworks/05/src/demonstration1/variables.tf
@@ -19,19 +19,3 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
-
-variable "vpc_name" {
-  type        = string
-  default     = "develop"
-  description = "VPC network&subnet name"
-}
-
-variable "public_key" {
-  type    = string
-  default = ""
-}


### PR DESCRIPTION
### Tflint
```
WARNING: "tflint FILE/DIR" is deprecated and will error in a future version. Use --chdir or --filter instead.
6 issue(s) found:

Warning: Missing version constraint for provider "yandex" in "required_providers" (terraform_required_providers)

  on tflint/main.tf line 36:
  36: resource "yandex_vpc_subnet" "develop" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md       

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on tflint/main.tf line 44:
  44:   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_module_pinned_source.md     

Warning: Missing version constraint for provider "template" in "required_providers" (terraform_required_providers)

  on tflint/main.tf line 62:
  62: data "template_file" "cloudinit" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md       

Warning: variable "default_cidr" is declared but not used (terraform_unused_declarations)

  on tflint/variables.tf line 22:
  22: variable "default_cidr" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_unused_declarations.md      

Warning: variable "vpc_name" is declared but not used (terraform_unused_declarations)

  on tflint/variables.tf line 28:
  28: variable "vpc_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_unused_declarations.md      

Warning: variable "public_key" is declared but not used (terraform_unused_declarations)

  on tflint/variables.tf line 34:
  34: variable "public_key" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_unused_declarations.md      
```


### Checkov
```
       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By bridgecrew.io | version: 2.3.293
Update available 2.3.293 -> 2.3.309
Run pip3 install -U checkov to update


terraform scan results:

Passed checks: 2, Failed checks: 4, Skipped checks: 0

Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.test-vm.yandex_compute_instance.vm[0]
        File: /yandex_compute_instance/main.tf:24-73
        Calling File: /main.tf:50-67
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.test-vm.yandex_compute_instance.vm[1]
        File: /yandex_compute_instance/main.tf:24-73
        Calling File: /main.tf:50-67
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        FAILED for resource: module.test-vm.yandex_compute_instance.vm[0]
        File: /yandex_compute_instance/main.tf:24-73
        Calling File: /main.tf:50-67

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        FAILED for resource: module.test-vm.yandex_compute_instance.vm[0]
        File: /yandex_compute_instance/main.tf:24-73
        Calling File: /main.tf:50-67

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        FAILED for resource: module.test-vm.yandex_compute_instance.vm[1]
        File: /yandex_compute_instance/main.tf:24-73
        Calling File: /main.tf:50-67

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        FAILED for resource: module.test-vm.yandex_compute_instance.vm[1]
        File: /yandex_compute_instance/main.tf:24-73
        Calling File: /main.tf:50-67

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
```


### terraform plan
```
data.template_file.cloudinit: Reading...
data.template_file.cloudinit: Read complete after 0s [id=16bfaa0be1c6999c0e565b49ded1609b7b1cb62525d96a6b487c7a41ec2f153b]
module.test-vm.data.yandex_compute_image.my_image: Reading...
yandex_vpc_network.develop: Refreshing state... [id=enplne6n1tolir8tolgu]
module.test-vm.data.yandex_compute_image.my_image: Read complete after 1s [id=fd852pbtueis1q0pbt4o]
yandex_vpc_subnet.develop: Refreshing state... [id=e9b365v6mgia7bf9vj53]
module.test-vm.yandex_compute_instance.vm[1]: Refreshing state... [id=fhm4ar4tq75qugd45gkp]
module.test-vm.yandex_compute_instance.vm[0]: Refreshing state... [id=fhmu5sa2fbcsehndlbjo]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # yandex_vpc_security_group.security_group will be created
  + resource "yandex_vpc_security_group" "security_group" {
      + created_at  = (known after apply)
      + description = "Description for security group develop"
      + folder_id   = (known after apply)
      + id          = (known after apply)
      + labels      = (known after apply)
      + name        = "Security group develop"
      + network_id  = "enplne6n1tolir8tolgu"
      + status      = (known after apply)
    }

  # module.test-vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhmu5sa2fbcsehndlbjo"
      ~ metadata                  = {
          - "serial-port-enable" = "1" -> null
            # (1 unchanged element hidden)
        }
        name                      = "develop-web-0"
        # (11 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [] -> (known after apply)
            # (8 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

  # module.test-vm.yandex_compute_instance.vm[1] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhm4ar4tq75qugd45gkp"
      ~ metadata                  = {
          - "serial-port-enable" = "1" -> null
            # (1 unchanged element hidden)
        }
        name                      = "develop-web-1"
        # (11 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [] -> (known after apply)
            # (8 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

Plan: 1 to add, 2 to change, 0 to destroy.
╷
│ Warning: Version constraints inside provider configuration blocks are deprecated
│
│   on yandex_compute_instance\providers.tf line 2, in provider "template":
│    2:   version = "2.2.0"
│
│ Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future version of Terraform. To silence this warning, 
│ move the provider version constraint into the required_providers block.
╵

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
Releasing state lock. This may take a few moments...
```
